### PR TITLE
MC-30191: Keystone does not allow the type anymore for use/password auth

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-core</artifactId>
-    <version>co-3.12.2</version>
+    <version>co-3.12.3</version>
     <name>OpenStack4j Core</name>
     <description>OpenStack Java API</description>
     <url>https://github.com/openstack4j/openstack4j/</url>

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
@@ -51,7 +51,6 @@ public class KeystoneAuth implements Authentication, AuthStore {
     public KeystoneAuth(String user, String password, Identifier domain, AuthScope scope) {
         this.identity = AuthIdentity.createCredentialType(user, password, domain);
         this.scope = scope;
-        this.type = Type.CREDENTIALS;
     }
 
     public KeystoneAuth(AuthScope scope, Type type) {
@@ -200,13 +199,15 @@ public class KeystoneAuth implements Authentication, AuthStore {
                     this.password = password;
                     if (domainIdentifier != null) {
                         domain = new AuthDomain();
-                        if (domainIdentifier.isTypeID())
-                            domain.setId(domainIdentifier.getId());
-                        else
-                            domain.setName(domainIdentifier.getId());
+                        if (domainIdentifier.isTypeID()) {
+                           domain.setId(domainIdentifier.getId());
+                        } else {
+                           domain.setName(domainIdentifier.getId());
+                        }
                         setName(username);
-                    } else
-                        setId(username);
+                    } else {
+                       setId(username);
+                    }
                 }
 
                 @Override
@@ -342,10 +343,11 @@ public class KeystoneAuth implements Authentication, AuthStore {
             private String name;
 
             public AuthDomain(Identifier domain) {
-                if (domain.isTypeID())
-                    this.id = domain.getId();
-                else
-                    this.name = domain.getId();
+                if (domain.isTypeID()) {
+                   this.id = domain.getId();
+                } else {
+                   this.name = domain.getId();
+                }
             }
 
             @Override

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/domain/KeystoneAuth.java
@@ -51,6 +51,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
     public KeystoneAuth(String user, String password, Identifier domain, AuthScope scope) {
         this.identity = AuthIdentity.createCredentialType(user, password, domain);
         this.scope = scope;
+        this.type = Type.CREDENTIALS;
     }
 
     public KeystoneAuth(AuthScope scope, Type type) {
@@ -62,6 +63,7 @@ public class KeystoneAuth implements Authentication, AuthStore {
         this.type = type;
     }
 
+    @JsonIgnore
     public Type getType() {
         return type;
     }


### PR DESCRIPTION
### Fixes [MC-30191](https://cloud-ops.atlassian.net/browse/MC-30191)

#### Code walkthrough : @INSERT_NAME
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
There is an issue with the serialization. Right now it assumes that it is only on the attributes. However, it seems to be using the method as well.

#### Solution
Added add ignore

#### Test cases
- Tested locally and it is working


#### Related PRs
- PR # https://github.com/cloudops/cloudmc-swift-plugin/pull/148
- PR # https://github.com/cloudops/cloudmc-openstack-plugin/pull/157
- PR # https://github.com/cloudops/cloudmc-swiftstack-plugin/pull/102
- PR # https://github.com/cloudops/openstack4j/pull/9


[MC-30191]: https://aptum.atlassian.net/browse/MC-30191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ