### PR TITLE
MC-30907: Fixed issue with renamed

### DIFF
--- a/connectors/http-connector/pom.xml
+++ b/connectors/http-connector/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <name>OpenStack4j HttpURL Connector</name>
     <artifactId>openstack4j-http-connector</artifactId>

--- a/connectors/http-connector/pom.xml
+++ b/connectors/http-connector/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <name>OpenStack4j HttpURL Connector</name>
     <artifactId>openstack4j-http-connector</artifactId>

--- a/connectors/httpclient/pom.xml
+++ b/connectors/httpclient/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-httpclient</artifactId>

--- a/connectors/jersey2-jakarta/pom.xml
+++ b/connectors/jersey2-jakarta/pom.xml
@@ -5,21 +5,35 @@
         <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>openstack4j-httpclient</artifactId>
-    <name>OpenStack4j HttpComponents-HttpClient Connector</name>
+    <artifactId>openstack4j-jersey2-jakarta</artifactId>
+    <name>OpenStack4j Jersey2 Jakarta Connector</name>
     <url>https://github.com/openstack4j/openstack4j/</url>
     <packaging>jar</packaging>
 
     <properties>
-        <httpclient-version>4.3.1</httpclient-version>
+        <jersey-version>3.1.10</jersey-version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
-            <type>jar</type>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>${jersey-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>${jersey-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>4.0.0</version>
         </dependency>
     </dependencies>
 
@@ -33,10 +47,10 @@
                     <instructions>
                         <Bundle-Name>${project.name}</Bundle-Name>
                         <Export-Package>
-                            org.openstack4j.connectors.httpclient
+                            org.openstack4j.connectors.jersey2
                         </Export-Package>
                         <Import-Package>
-                            !org.openstack4j.connectors.httpclient,
+                            !org.openstack4j.connectors.jersey2,
                             *
                         </Import-Package>
                         <!--
@@ -57,5 +71,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/connectors/jersey2-jakarta/pom.xml
+++ b/connectors/jersey2-jakarta/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-jersey2-jakarta</artifactId>

--- a/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/ClientFactory.java
+++ b/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/ClientFactory.java
@@ -1,0 +1,140 @@
+package org.openstack4j.connectors.jersey2;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Proxy.Type;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.ext.ContextResolver;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider.ConnectionFactory;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.openstack4j.api.exceptions.ConnectionException;
+import org.openstack4j.core.transport.ClientConstants;
+import org.openstack4j.core.transport.Config;
+import org.openstack4j.core.transport.ObjectMapperSingleton;
+import org.openstack4j.core.transport.UntrustedSSL;
+
+/**
+ * A factory for creating a rest Client which is mapped to Jackson for JSON processing.
+ *
+ * @author Jeremy Unruh
+ */
+class ClientFactory {
+
+    private static final CustomContextResolver RESOLVER = new CustomContextResolver();
+    private static LoadingCache<Config, Client> CACHE = CacheBuilder.newBuilder()
+            .expireAfterAccess(20, TimeUnit.MINUTES)
+            .build(new CacheLoader<Config, Client>() {
+                @Override
+                public Client load(Config config) throws Exception {
+                    return buildClientFromConfig(config);
+                }
+            });
+
+    /**
+     * Creates or Returns a Client
+     *
+     * @param config the configuration to use for the given client
+     * @return the client
+     */
+    static Client create(Config config) {
+        try {
+            return CACHE.get(config);
+        } catch (ExecutionException e) {
+            throw new ConnectionException("Issue creating Jersey 2 Client: " + e.getMessage(), 0, e);
+        }
+    }
+
+    private static Client buildClientFromConfig(Config config) {
+        ClientConfig clientConfig = new ClientConfig();
+
+        if (config.getProxy() != null) {
+            addProxy(clientConfig, config);
+        }
+
+        ClientBuilder cb = ClientBuilder.newBuilder()
+                .withConfig(clientConfig)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, "true")
+                .register(JacksonFeature.class)
+                .register(RESOLVER)
+                .register(new RequestFilter());
+
+        if (config.getSslContext() != null) {
+            cb.sslContext(config.getSslContext());
+        } else if (config.isIgnoreSSLVerification()) {
+            cb.sslContext(UntrustedSSL.getSSLContext());
+        }
+
+        if (config.getHostNameVerifier() != null) {
+            cb.hostnameVerifier(config.getHostNameVerifier());
+        } else if (config.isIgnoreSSLVerification()) {
+            cb.hostnameVerifier(UntrustedSSL.getHostnameVerifier());
+        }
+
+        if (config.getReadTimeout() > 0) {
+            cb.property(ClientProperties.READ_TIMEOUT, config.getReadTimeout());
+        }
+
+        if (config.getConnectTimeout() > 0) {
+            cb.property(ClientProperties.CONNECT_TIMEOUT, config.getConnectTimeout());
+        }
+
+        return cb.build();
+    }
+
+    private static void addProxy(ClientConfig cc, Config config) {
+        if (config.getProxy() != null) {
+            HttpUrlConnectorProvider cp = new HttpUrlConnectorProvider();
+            cc.connectorProvider(cp);
+            final Proxy proxy = new Proxy(Type.HTTP,
+                    new InetSocketAddress(config.getProxy().getRawHost(), config.getProxy().getPort()));
+
+            cp.connectionFactory(new ConnectionFactory() {
+
+                @Override
+                public HttpURLConnection getConnection(URL url) throws IOException {
+                    return (HttpURLConnection) url.openConnection(proxy);
+                }
+            });
+        }
+    }
+
+    private static final class RequestFilter implements ClientRequestFilter {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void filter(ClientRequestContext requestContext) throws IOException {
+            requestContext.getHeaders().remove(ClientConstants.HEADER_CONTENT_LANGUAGE);
+            requestContext.getHeaders().remove(ClientConstants.HEADER_CONTENT_ENCODING);
+        }
+    }
+
+    private static final class CustomContextResolver implements ContextResolver<ObjectMapper> {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ObjectMapper getContext(Class<?> type) {
+            return ObjectMapperSingleton.getContext(type);
+        }
+
+    }
+}

--- a/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/HttpCommand.java
+++ b/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/HttpCommand.java
@@ -1,0 +1,156 @@
+package org.openstack4j.connectors.jersey2;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
+import org.glassfish.jersey.client.RequestEntityProcessing;
+import org.glassfish.jersey.logging.LoggingFeature;
+import org.openstack4j.core.transport.ClientConstants;
+import org.openstack4j.core.transport.HttpRequest;
+import org.openstack4j.core.transport.internal.HttpLoggingFilter;
+
+/**
+ * HttpCommand is responsible for executing the actual request driven by the HttpExecutor.
+ */
+public final class HttpCommand<R> {
+
+    private HttpRequest<R> request;
+    private Entity<?> entity;
+    private Invocation.Builder invocation;
+    private int retries;
+
+    private HttpCommand(HttpRequest<R> request) {
+        this.request = request;
+    }
+
+    /**
+     * Creates a new HttpCommand from the given request
+     *
+     * @param request the request
+     * @return the command
+     */
+    public static <R> HttpCommand<R> create(HttpRequest<R> request) {
+        HttpCommand<R> command = new HttpCommand<R>(request);
+        command.initialize();
+        return command;
+    }
+
+    private void initialize() {
+        Client client = ClientFactory.create(request.getConfig());
+        //try to set unsupported HTTP method. In our case used for PATCH.
+        if ("PATCH".equals(request.getMethod().name())) {
+            client.property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true);
+        }
+
+        WebTarget target = client.target(request.getEndpoint()).path(request.getPath());
+
+        if (HttpLoggingFilter.isLoggingEnabled()) {
+            target.register(new LoggingFeature(Logger.getLogger("os"), 10000));
+        }
+
+        target = populateQueryParams(target, request);
+        invocation = target.request(MediaType.APPLICATION_JSON);
+
+        populateHeaders(invocation, request);
+
+        entity = (request.getEntity() == null) ? null: Entity.entity(request.getEntity(), request.getContentType());
+    }
+
+    /**
+     * Executes the command and returns the Response
+     *
+     * @return the response
+     */
+    public Response execute() {
+        Response response = null;
+
+        if (hasEntity()) {
+            if (isInputStreamEntity()) {
+                // Issue #20 - Out of Memory in Jersey for large streams
+                invocation.property(ClientProperties.CHUNKED_ENCODING_SIZE, 1024);
+                invocation.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.CHUNKED);
+            }
+            response = invocation.method(request.getMethod().name(), getEntity());
+        } else if (request.hasJson()) {
+            response = invocation.method(request.getMethod().name(), Entity.entity(request.getJson(), ClientConstants.CONTENT_TYPE_JSON));
+        } else {
+            response = invocation.method(request.getMethod().name());
+        }
+
+        return response;
+    }
+
+    private boolean isInputStreamEntity() {
+        return (hasEntity() && InputStream.class.isAssignableFrom(entity.getEntity().getClass()));
+    }
+
+    /**
+     * @return the request entity or null
+     */
+    public Entity<?> getEntity() {
+        return entity;
+    }
+
+    /**
+     * @return true if a request entity has been set
+     */
+    public boolean hasEntity() {
+        return entity != null;
+    }
+
+    /**
+     * @return current retry execution count for this command
+     */
+    public int getRetries() {
+        return retries;
+    }
+
+    /**
+     * @return incremement's the retry count and returns self
+     */
+    public HttpCommand<R> incrementRetriesAndReturn() {
+        initialize();
+        retries++;
+        return this;
+    }
+
+    public HttpRequest<R> getRequest() {
+        return request;
+    }
+
+    private WebTarget populateQueryParams(WebTarget target, HttpRequest<R> request) {
+
+        if (!request.hasQueryParams()) {
+            return target;
+        }
+
+        for (Map.Entry<String, List<Object>> entry : request.getQueryParams().entrySet()) {
+            for (Object o : entry.getValue()) {
+                target = target.queryParam(entry.getKey(), o);
+            }
+        }
+        return target;
+    }
+
+    private void populateHeaders(Invocation.Builder invocation, HttpRequest<R> request) {
+
+        if (!request.hasHeaders()) {
+            return;
+        }
+
+        for (Map.Entry<String, Object> h : request.getHeaders().entrySet()) {
+            invocation.header(h.getKey(), h.getValue());
+        }
+    }
+}

--- a/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/HttpExecutorServiceImpl.java
+++ b/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/HttpExecutorServiceImpl.java
@@ -1,0 +1,77 @@
+package org.openstack4j.connectors.jersey2;
+
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.Response;
+
+import org.openstack4j.api.exceptions.ConnectionException;
+import org.openstack4j.api.exceptions.ResponseException;
+import org.openstack4j.core.transport.ClientConstants;
+import org.openstack4j.core.transport.HttpExecutorService;
+import org.openstack4j.core.transport.HttpRequest;
+import org.openstack4j.core.transport.HttpResponse;
+import org.openstack4j.openstack.internal.OSAuthenticator;
+import org.openstack4j.openstack.internal.OSClientSession;
+
+/**
+ * HttpExecutor is the default implementation for HttpExecutorService which is responsible for interfacing with Jersey and mapping common status codes, requests and responses
+ * back to the common API
+ *
+ * @author Jeremy Unruh
+ */
+public class HttpExecutorServiceImpl implements HttpExecutorService {
+
+    private static final String NAME = "Jersey 2 Connector";
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <R> HttpResponse execute(HttpRequest<R> request) {
+        try {
+            return invoke(request);
+        } catch (ResponseException re) {
+            throw re;
+        } catch (Exception e) {
+            throw new ConnectionException("Error during execution: " + e, 0, e);
+        }
+    }
+
+    /**
+     * Invokes the given request
+     *
+     * @param <R> the return type
+     * @param request the request to invoke
+     * @return the response
+     * @throws Exception the exception
+     */
+    private <R> HttpResponse invoke(HttpRequest<R> request) throws Exception {
+
+        HttpCommand<R> command = HttpCommand.create(request);
+
+        try {
+            return invokeRequest(command);
+        } catch (ProcessingException pe) {
+            throw new ConnectionException(pe.getMessage(), 0, pe);
+        } catch (ClientErrorException e) {
+            throw ResponseException.mapException(e.getResponse().getStatusInfo().toString(), e.getResponse().getStatus(), e);
+        }
+    }
+
+    private <R> HttpResponse invokeRequest(HttpCommand<R> command) throws Exception {
+        Response response = command.execute();
+        if (command.getRetries() == 0 && response.getStatus() == 401 && !command.getRequest().getHeaders().containsKey(ClientConstants.HEADER_OS4J_AUTH)) {
+            OSAuthenticator.reAuthenticate();
+            command.getRequest().getHeaders().put(ClientConstants.HEADER_X_AUTH_TOKEN, OSClientSession.getCurrent().getTokenId());
+            return invokeRequest(command.incrementRetriesAndReturn());
+        }
+        return HttpResponseImpl.wrap(response);
+    }
+
+    @Override
+    public String getExecutorDisplayName() {
+        return NAME;
+    }
+
+}

--- a/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/HttpResponseImpl.java
+++ b/connectors/jersey2-jakarta/src/main/java/org/openstack4j/connectors/jersey2/HttpResponseImpl.java
@@ -1,0 +1,125 @@
+package org.openstack4j.connectors.jersey2;
+
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openstack4j.core.transport.ClientConstants;
+import org.openstack4j.core.transport.ExecutionOptions;
+import org.openstack4j.core.transport.HttpEntityHandler;
+import org.openstack4j.core.transport.HttpResponse;
+
+public class HttpResponseImpl implements HttpResponse {
+
+    private final Response response;
+
+    private HttpResponseImpl(Response response) {
+        this.response = response;
+    }
+
+    /**
+     * Wrap the given REsponse
+     *
+     * @param response the response
+     * @return the HttpResponse
+     */
+    public static HttpResponseImpl wrap(Response response) {
+        return new HttpResponseImpl(response);
+    }
+
+    /**
+     * Unwrap and return the original Response
+     *
+     * @return the response
+     */
+    public Response unwrap() {
+        return response;
+    }
+
+    /**
+     * Gets the entity and Maps any errors which will result in a ResponseException
+     *
+     * @param <T> the generic type
+     * @param returnType the return type
+     * @return the entity
+     */
+    public <T> T getEntity(Class<T> returnType) {
+        return getEntity(returnType, null);
+    }
+
+    /**
+     * Gets the entity and Maps any errors which will result in a ResponseException
+     *
+     * @param <T> the generic type
+     * @param returnType the return type
+     * @param options the execution options
+     * @return the entity
+     */
+    @Override
+    public <T> T getEntity(Class<T> returnType, ExecutionOptions<T> options) {
+        return HttpEntityHandler.handle(this, returnType, options);
+    }
+
+    /**
+     * Gets the status from the previous Request
+     *
+     * @return the status code
+     */
+    public int getStatus() {
+        return response.getStatus();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getStatusMessage() {
+        return response.getStatusInfo().getReasonPhrase();
+    }
+
+    /**
+     * @return the input stream
+     */
+    public InputStream getInputStream() {
+        return (InputStream) response.getEntity();
+    }
+
+    /**
+     * Returns a Header value from the specified name key
+     *
+     * @param name the name of the header to query for
+     * @return the header as a String or null if not found
+     */
+    public String header(String name) {
+        return response.getHeaderString(name);
+    }
+
+    /**
+     * @return the a Map of Header Name to Header Value
+     */
+    public Map<String, String> headers() {
+        Map<String, String> headers = new HashMap<String, String>();
+        for (String k : response.getHeaders().keySet()) {
+            headers.put(k, response.getHeaderString(k));
+        }
+        return headers;
+    }
+
+    @Override
+    public <T> T readEntity(Class<T> typeToReadAs) {
+        return response.readEntity(typeToReadAs);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Jersey handles this automatically in all cases - no-op
+    }
+
+    @Override
+    public String getContentType() {
+        return header(ClientConstants.HEADER_CONTENT_TYPE);
+    }
+}

--- a/connectors/jersey2-jakarta/src/main/resources/META-INF/services/org.openstack4j.core.transport.HttpExecutorService
+++ b/connectors/jersey2-jakarta/src/main/resources/META-INF/services/org.openstack4j.core.transport.HttpExecutorService
@@ -1,0 +1,1 @@
+org.openstack4j.connectors.jersey2.HttpExecutorServiceImpl

--- a/connectors/jersey2/pom.xml
+++ b/connectors/jersey2/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-jersey2</artifactId>

--- a/connectors/jersey2/pom.xml
+++ b/connectors/jersey2/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-jersey2</artifactId>

--- a/connectors/okhttp/pom.xml
+++ b/connectors/okhttp/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-okhttp</artifactId>

--- a/connectors/okhttp/pom.xml
+++ b/connectors/okhttp/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-okhttp</artifactId>

--- a/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpCommand.java
+++ b/connectors/okhttp/src/main/java/org/openstack4j/connectors/okhttp/HttpCommand.java
@@ -49,22 +49,26 @@ public final class HttpCommand<R> {
                     new InetSocketAddress(config.getProxy().getRawHost(), config.getProxy().getPort())));
         }
 
-        if (config.getConnectTimeout() > 0)
-            okHttpClientBuilder.connectTimeout(config.getConnectTimeout(), TimeUnit.MILLISECONDS);
+        if (config.getConnectTimeout() > 0) {
+           okHttpClientBuilder.connectTimeout(config.getConnectTimeout(), TimeUnit.MILLISECONDS);
+        }
 
-        if (config.getReadTimeout() > 0)
-            okHttpClientBuilder.readTimeout(config.getReadTimeout(), TimeUnit.MILLISECONDS);
+        if (config.getReadTimeout() > 0) {
+           okHttpClientBuilder.readTimeout(config.getReadTimeout(), TimeUnit.MILLISECONDS);
+        }
 
         if (config.isIgnoreSSLVerification()) {
             okHttpClientBuilder.hostnameVerifier(UntrustedSSL.getHostnameVerifier());
             okHttpClientBuilder.sslSocketFactory(UntrustedSSL.getSSLContext().getSocketFactory(), UntrustedSSL.getTrustManager());
         }
 
-        if (config.getSslContext() != null)
-            okHttpClientBuilder.sslSocketFactory(config.getSslContext().getSocketFactory());
+        if (config.getSslContext() != null) {
+           okHttpClientBuilder.sslSocketFactory(config.getSslContext().getSocketFactory());
+        }
 
-        if (config.getHostNameVerifier() != null)
-            okHttpClientBuilder.hostnameVerifier(config.getHostNameVerifier());
+        if (config.getHostNameVerifier() != null) {
+           okHttpClientBuilder.hostnameVerifier(config.getHostNameVerifier());
+        }
         if (HttpLoggingFilter.isLoggingEnabled()) {
             okHttpClientBuilder.addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY));
         }
@@ -148,7 +152,9 @@ public final class HttpCommand<R> {
 
     private void populateHeaders(HttpRequest<R> request) {
 
-        if (!request.hasHeaders()) return;
+        if (!request.hasHeaders()) {
+           return;
+        }
 
         for (Map.Entry<String, Object> h : request.getHeaders().entrySet()) {
             clientReq.addHeader(h.getKey(), String.valueOf(h.getValue()));

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -22,7 +22,6 @@
                 <module>http-connector</module>
                 <module>httpclient</module>
                 <module>jersey2</module>
-                <module>jersey2-jakarta</module>
                 <module>okhttp</module>
                 <module>resteasy</module>
             </modules>
@@ -36,7 +35,6 @@
                 <!-- <module>http-connector</module> org.openstack4j.connectors.http.HttpCommand.setRequestMethodUsingWorkaroundForJREBug -->
                 <module>httpclient</module>
                 <!--<module>jersey2</module> https://github.com/eclipse-ee4j/jersey/issues/4825 -->
-                <module>jersey2-jakarta</module>
                 <module>okhttp</module>
                 <module>resteasy</module>
             </modules>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.openstack4j.core.connectors</groupId>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.openstack4j.core.connectors</groupId>
@@ -22,6 +22,7 @@
                 <module>http-connector</module>
                 <module>httpclient</module>
                 <module>jersey2</module>
+                <module>jersey2-jakarta</module>
                 <module>okhttp</module>
                 <module>resteasy</module>
             </modules>
@@ -35,6 +36,7 @@
                 <!-- <module>http-connector</module> org.openstack4j.connectors.http.HttpCommand.setRequestMethodUsingWorkaroundForJREBug -->
                 <module>httpclient</module>
                 <!--<module>jersey2</module> https://github.com/eclipse-ee4j/jersey/issues/4825 -->
+                <module>jersey2-jakarta</module>
                 <module>okhttp</module>
                 <module>resteasy</module>
             </modules>
@@ -48,6 +50,7 @@
                 <!-- <module>http-connector</module> org.openstack4j.connectors.http.HttpCommand.setRequestMethodUsingWorkaroundForJREBug -->
                 <module>httpclient</module>
                 <!--<module>jersey2</module> https://github.com/eclipse-ee4j/jersey/issues/4825 -->
+                <module>jersey2-jakarta</module>
                 <module>okhttp</module>
                 <module>resteasy</module>
             </modules>
@@ -91,6 +94,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
+                    <argLine>--add-opens java.base/java.net=ALL-UNNAMED</argLine>
                     <suiteXmlFiles>
                         <suiteXmlFile>../../core-test/src/main/resources/all.xml</suiteXmlFile>
                     </suiteXmlFiles>

--- a/connectors/resteasy/pom.xml
+++ b/connectors/resteasy/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-resteasy</artifactId>

--- a/connectors/resteasy/pom.xml
+++ b/connectors/resteasy/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core.connectors</groupId>
         <artifactId>openstack4j-connectors</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-resteasy</artifactId>

--- a/core-integration-test/it-httpclient/pom.xml
+++ b/core-integration-test/it-httpclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <artifactId>it-httpclient</artifactId>
     <name>OpenStack4j IntegrationTest Apache HttpClient</name>

--- a/core-integration-test/it-httpclient/pom.xml
+++ b/core-integration-test/it-httpclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <artifactId>it-httpclient</artifactId>
     <name>OpenStack4j IntegrationTest Apache HttpClient</name>

--- a/core-integration-test/it-jersey2-jakarta/pom.xml
+++ b/core-integration-test/it-jersey2-jakarta/pom.xml
@@ -5,8 +5,8 @@
         <artifactId>openstack4j-core-integration-test</artifactId>
         <version>co-3.12.3</version>
     </parent>
-    <artifactId>it-jersey2</artifactId>
-    <name>OpenStack4j IntegrationTest Jersey2 Connector</name>
+    <artifactId>it-jersey2-jakarta</artifactId>
+    <name>OpenStack4j IntegrationTest Jersey2 Jakarta Connector</name>
     <properties>
         <skipTests>false</skipTests>
     </properties>
@@ -14,7 +14,7 @@
     <dependencies>
         <dependency>
             <groupId>com.github.openstack4j.core.connectors</groupId>
-            <artifactId>openstack4j-jersey2</artifactId>
+            <artifactId>openstack4j-jersey2-jakarta</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/core-integration-test/it-jersey2-jakarta/pom.xml
+++ b/core-integration-test/it-jersey2-jakarta/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <artifactId>it-jersey2-jakarta</artifactId>
     <name>OpenStack4j IntegrationTest Jersey2 Jakarta Connector</name>

--- a/core-integration-test/it-jersey2/pom.xml
+++ b/core-integration-test/it-jersey2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <artifactId>it-jersey2</artifactId>
     <name>OpenStack4j IntegrationTest Jersey2 Connector</name>

--- a/core-integration-test/it-okhttp/pom.xml
+++ b/core-integration-test/it-okhttp/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <artifactId>it-okhttp</artifactId>
     <name>OpenStack4j IntegrationTest OKHttp Connector</name>

--- a/core-integration-test/it-okhttp/pom.xml
+++ b/core-integration-test/it-okhttp/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <artifactId>it-okhttp</artifactId>
     <name>OpenStack4j IntegrationTest OKHttp Connector</name>

--- a/core-integration-test/it-resteasy/pom.xml
+++ b/core-integration-test/it-resteasy/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <artifactId>it-resteasy</artifactId>
     <name>OpenStack4j IntegrationTest RestEasy Connector</name>

--- a/core-integration-test/it-resteasy/pom.xml
+++ b/core-integration-test/it-resteasy/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-core-integration-test</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <artifactId>it-resteasy</artifactId>
     <name>OpenStack4j IntegrationTest RestEasy Connector</name>

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-core-integration-test</artifactId>

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-core-integration-test</artifactId>
@@ -19,6 +19,7 @@
     <!-- dedicated module per connector to test -->
     <modules>
         <module>it-jersey2</module>
+        <module>it-jersey2-jakarta</module>
         <module>it-resteasy</module>
         <module>it-okhttp</module>
         <module>it-httpclient</module>

--- a/core-integration-test/pom.xml
+++ b/core-integration-test/pom.xml
@@ -17,13 +17,46 @@
     </properties>
 
     <!-- dedicated module per connector to test -->
-    <modules>
-        <module>it-jersey2</module>
-        <module>it-jersey2-jakarta</module>
-        <module>it-resteasy</module>
-        <module>it-okhttp</module>
-        <module>it-httpclient</module>
-    </modules>
+    <profiles>
+        <profile>
+            <id>java-11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <modules>
+                <module>it-httpclient</module>
+                <module>it-jersey2</module>
+                <module>it-okhttp</module>
+                <module>it-resteasy</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <modules>
+                <module>it-httpclient</module>
+                <!--<module>it-jersey2</module> https://github.com/eclipse-ee4j/jersey/issues/4825 -->
+                <module>it-okhttp</module>
+                <module>it-resteasy</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>java-21</id>
+            <activation>
+                <jdk>21</jdk>
+            </activation>
+            <modules>
+                <!-- <module>http-connector</module> org.openstack4j.connectors.http.HttpCommand.setRequestMethodUsingWorkaroundForJREBug -->
+                <module>it-httpclient</module>
+                <!--<module>it-jersey2</module> https://github.com/eclipse-ee4j/jersey/issues/4825 -->
+                <module>it-jersey2-jakarta</module>
+                <module>it-okhttp</module>
+                <module>it-resteasy</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-core-test</artifactId>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-core-test</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,11 +2,10 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-core</artifactId>
-    <version>co-3.12.3</version>
     <name>OpenStack4j Core</name>
     <description>OpenStack Java API</description>
     <url>https://github.com/openstack4j/openstack4j/</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j-core</artifactId>

--- a/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/OSAuthenticator.java
@@ -143,8 +143,9 @@ public class OSAuthenticator {
             access = access.applyContext(info.endpoint, (org.openstack4j.openstack.identity.v2.domain.TokenAuth) auth);
         }
 
-        if (!info.reLinkToExistingSession)
-            return OSClientSession.OSClientSessionV2.createSession(access, info.perspective, info.provider, config);
+        if (!info.reLinkToExistingSession) {
+           return OSClientSessionV2.createSession(access, info.perspective, info.provider, config);
+        }
 
         OSClientSession.OSClientSessionV2 current = (OSClientSessionV2) OSClientSession.getCurrent();
         current.access = access;
@@ -156,24 +157,30 @@ public class OSAuthenticator {
             Map<String, String> headers = new HashMap<>();
             Authentication.Scope.Project project = auth.getScope().getProject();
             if (project != null) {
-                if (!isEmpty(project.getId()))
-                    headers.put(ClientConstants.HEADER_X_PROJECT_ID, project.getId());
-                if (!isEmpty(project.getName()))
-                    headers.put(ClientConstants.HEADER_X_PROJECT_NAME, project.getName());
+                if (!isEmpty(project.getId())) {
+                   headers.put(ClientConstants.HEADER_X_PROJECT_ID, project.getId());
+                }
+                if (!isEmpty(project.getName())) {
+                   headers.put(ClientConstants.HEADER_X_PROJECT_NAME, project.getName());
+                }
                 Authentication.Scope.Domain domain = project.getDomain();
                 if (domain != null) {
-                    if (!isEmpty(domain.getId()))
-                        headers.put(ClientConstants.HEADER_X_PROJECT_DOMAIN_ID, domain.getId());
-                    if (!isEmpty(domain.getName()))
-                        headers.put(ClientConstants.HEADER_X_PROJECT_DOMAIN_NAME, domain.getName());
+                    if (!isEmpty(domain.getId())) {
+                       headers.put(ClientConstants.HEADER_X_PROJECT_DOMAIN_ID, domain.getId());
+                    }
+                    if (!isEmpty(domain.getName())) {
+                       headers.put(ClientConstants.HEADER_X_PROJECT_DOMAIN_NAME, domain.getName());
+                    }
                 }
             } else {
                 Authentication.Scope.Domain domain = auth.getScope().getDomain();
                 if (domain != null) {
-                    if (!isEmpty(domain.getId()))
-                        headers.put(ClientConstants.HEADER_X_DOMAIN_ID, domain.getId());
-                    if (!isEmpty(domain.getName()))
-                        headers.put(ClientConstants.HEADER_X_DOMAIN_NAME, domain.getName());
+                    if (!isEmpty(domain.getId())) {
+                       headers.put(ClientConstants.HEADER_X_DOMAIN_ID, domain.getId());
+                    }
+                    if (!isEmpty(domain.getName())) {
+                       headers.put(ClientConstants.HEADER_X_DOMAIN_NAME, domain.getName());
+                    }
                 }
             }
             KeystoneToken keystoneToken = new KeystoneToken();
@@ -230,8 +237,9 @@ public class OSAuthenticator {
     }
 
     private static boolean isEmpty(String str) {
-        if (str != null && str.length() > 0)
-            return false;
+        if (str != null && str.length() > 0) {
+           return false;
+        }
         return true;
     }
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>3.12</version>
+        <version>co-3.12.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>com.github.openstack4j.core</groupId>
         <artifactId>openstack4j-parent</artifactId>
-        <version>co-3.12.3</version>
+        <version>co-3.12.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openstack4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.openstack4j.core</groupId>
     <artifactId>openstack4j-parent</artifactId>
-    <version>co-3.12.3</version>
+    <version>co-3.12.4</version>
     <name>OpenStack4j Parent</name>
     <description>OpenStack Java API</description>
     <url>https://github.com/openstack4j/openstack4j/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.openstack4j.core</groupId>
     <artifactId>openstack4j-parent</artifactId>
-    <version>3.12</version>
+    <version>co-3.12.3</version>
     <name>OpenStack4j Parent</name>
     <description>OpenStack Java API</description>
     <url>https://github.com/openstack4j/openstack4j/</url>


### PR DESCRIPTION

# PR description

This is the 3 attempt to fix Swift Connection that is failing. We used to use Jersey, but with the spring boot migration that is now using Jakarta instead of Javax packages. It failed.

We tried to use OkHttp, but it triggered connection error to often closed by GCP.

We switch to HttpClient, but we cannot rename files since there is an error because of Content-Length already set.

So this PR is to create a new jersey client using Jakarta implementation instead of javax.